### PR TITLE
Added support for x-www-form-urlencoded

### DIFF
--- a/fastapi_xray/xray.py
+++ b/fastapi_xray/xray.py
@@ -185,7 +185,19 @@ async def extract_body(body: bytes, request: Request) -> bytes:
         # https://stackoverflow.com/a/74778485/6832201
         await set_body(request, await request.body())
         body = await request.json()
+    elif request.headers.get("Content-Type") == "application/x-www-form-urlencoded":
+        await set_body(request, await request.body())
+        form_data = await form_to_json(request)
+        return form_data
     return body
+
+async def form_to_json(request: Request):
+        form_data = await request.form()
+        form_items = form_data.items()
+        form_body = {}
+        for item in form_items:
+            form_body[item[0]] = item[1]
+        return form_body
 
 
 def send_debug_info(debug_info: Dict):


### PR DESCRIPTION
I have added support for request which is submitted as a urlencoded form.

Consider an API like below:

```python
@app.post("/login")
def login(username: Annotated[str, Form()], password: Annotated[str, Form()]):
    return {"username": username}
```

And a curl request sent like below:
```bash
curl --request POST \
  --url http://localhost:8000/login \
  --header 'Content-Type: application/x-www-form-urlencoded' \
  --data username=testuser \
  --data password=testpassword
```


It is currently formatted as a json object as shown below.
![image](https://github.com/ropali/fastapi_xray/assets/36756474/f474059e-75dc-4647-927b-a16fd3026997)

Feel free to let me know if I should change anything.